### PR TITLE
Allow to pass maps in functions typespecs

### DIFF
--- a/lib/pigeon/apns/notification.ex
+++ b/lib/pigeon/apns/notification.ex
@@ -66,7 +66,7 @@ defmodule Pigeon.APNS.Notification do
         topic: nil
       }
   """
-  @spec new(String.t(), String.t(), String.t() | nil) :: t
+  @spec new(String.t() | map, String.t(), String.t() | nil) :: t
   def new(msg, token, topic \\ nil) do
     %Notification{
       device_token: token,
@@ -93,7 +93,7 @@ defmodule Pigeon.APNS.Notification do
         topic: "topic"
       }
   """
-  @spec new(String.t(), String.t(), String.t(), String.t()) :: t
+  @spec new(String.t() | map, String.t(), String.t(), String.t()) :: t
   def new(msg, token, topic, id) do
     %Notification{
       device_token: token,
@@ -120,7 +120,7 @@ defmodule Pigeon.APNS.Notification do
         topic: nil
       }
   """
-  @spec put_alert(t, String.t()) :: t
+  @spec put_alert(t, String.t() | map) :: t
   def put_alert(notification, alert),
     do: update_payload(notification, "alert", alert)
 


### PR DESCRIPTION
Functions `put_alert` and `new` now can accept `map` type for the second and the first arguments accordingly.